### PR TITLE
Announce releases on Discord

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
         run: npm ci
 
       - name: Release
-        run: npx semantic-release
+        use: cycjimmy/semantic-release-action@v2
+        with:
+          semantic_version: 17
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,17 @@ jobs:
 
       - name: Release
         use: cycjimmy/semantic-release-action@v2
+        id: release
         with:
           semantic_version: 17
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Announce to Discord
+        if: steps.release.outputs.new_release_published == 'true'
+        run: |
+          curl \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            -d '{ "content": "@everyone, ${{ steps.release.outputs.new_release_version }} is now available!" }' \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
Announcing new releases on Discord helps promote engagement, so I've added an extra step during release that invokes the Discord webhook.