### PR TITLE
Fix #56 - Undefined actors crashes app

### DIFF
--- a/src/components/control-panel/ActorList.tsx
+++ b/src/components/control-panel/ActorList.tsx
@@ -18,7 +18,7 @@ export const ActorList = () =>
     removeActor,
   }));
 
-  if (actors.length === 0)
+  if (!actors || actors.length === 0)
   {
     return (
       <span className={styles["no-actors"]}>...No actors...</span>


### PR DESCRIPTION
This is a hotfix for #56. Users connecting to a room where their peers are far away would experience a brief time where the shared state would be totally empty. This resulted in errors being thrown by components that relied on the shared state existing.