### PR TITLE
Fixed actor list exceeding view height

### DIFF
--- a/src/feature/actor/component/ActorPanel.module.css
+++ b/src/feature/actor/component/ActorPanel.module.css
@@ -7,6 +7,11 @@ span {
     font-weight: bold;
 }
 
+.list-container {
+    max-height: 300px;
+    overflow-y: auto;
+}
+
 ul {
     list-style: none;
 }

--- a/src/feature/actor/component/ActorPanel.tsx
+++ b/src/feature/actor/component/ActorPanel.tsx
@@ -33,20 +33,22 @@ export const ActorPanel = (): any =>
           <p className={styles["no-actors"]}>... No actors ...</p>
         )
         : (
-          <ul>
-            {
-              actors.map((actor) =>
-                (
-                  <li
-                    key={actor.id}
-                    onClick={() => removeActor(actor.id)}
-                  >
-                    {actor.name}
-                  </li>
+          <div className={styles["list-container"]}>
+            <ul>
+              {
+                actors.map((actor) =>
+                  (
+                    <li
+                      key={actor.id}
+                      onClick={() => removeActor(actor.id)}
+                    >
+                      {actor.name}
+                    </li>
+                  )
                 )
-              )
-            }
-          </ul>
+              }
+            </ul>
+          </div>
         )
       }
     </>


### PR DESCRIPTION
If the actor list got sufficiently full of actors, it would stretch past the bottom of the view and ruin the app layout.