### PR TITLE
Give max zoom level for viewport (fixes #68)

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Install webkit dependencies
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
+          sudo apt-get update \
           sudo apt-get install --yes \
             libegl1 \
             libopus0 \

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install webkit dependencies
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          sudo apt-get update \
+          sudo apt-get update
           sudo apt-get install --yes \
             libegl1 \
             libopus0 \

--- a/src/feature/grid/component/Grid.spec.tsx
+++ b/src/feature/grid/component/Grid.spec.tsx
@@ -315,4 +315,28 @@ describe("Connected Grid component", () =>
       [   0,   0,                1 ],
     ]);
   });
+
+  it("Zooms to a minimum of 0.1.", () =>
+  {
+    const clientX = 10, clientY = 12, deltaY = 100;
+
+    useLocalStore.getState().setViewTransform([
+      [ 0.1,   0, 0 ],
+      [   0, 0.1, 0 ],
+      [   0,   0, 0 ],
+    ]);
+
+    const { getByTestId } = renderSVG(<Grid patternId={null} />);
+
+    const grid = getByTestId(gridTestId);
+
+    fireEvent.wheel(grid, { deltaY, clientX, clientY });
+
+    expect(useLocalStore.getState().viewTransform)
+    .toStrictEqual([
+      [ 0.1,   0, 0 ],
+      [   0, 0.1, 0 ],
+      [   0,   0, 1 ],
+    ]);
+  });
 });

--- a/src/feature/grid/component/Grid.tsx
+++ b/src/feature/grid/component/Grid.tsx
@@ -84,7 +84,20 @@ export const Grid = ({ patternId, }: GridProps) =>
             clientY * (1 - zoomFactor)
           ));
 
-          setViewTransform(pan(zoom(viewTransform)));
+          const [
+            [ newScale, , newX ],
+            [         , , newY ],
+          ] = pan(zoom(viewTransform));
+
+          const actualScale = Math.max(newScale, 0.1);
+
+          setViewTransform(
+            [
+              [ actualScale,           0, newX ],
+              [           0, actualScale, newY ],
+              [           0,           0,    1 ],
+            ]
+          );
         }
       }
     />


### PR DESCRIPTION
#68 brought attention to a problem with zooming out. Apparently, when you zoom out too far, the transform matrix begins to contain numbers that can't be used by SVG. This fixes that by setting a minimum scale (i.e. maximum zoom).