### PR TITLE
Prevent actors from being duplicated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,5 +50,5 @@ jobs:
           curl \
             -X POST \
             -H 'Content-Type: application/json' \
-            -d '{ "content": "@everyone, version ${{ steps.release.outputs.new_release_version }} is now available! [Check it out!](https://alpha.repeatedpleasant.games)" }' \
+            -d '{ "content": "@everyone, version ${{ steps.release.outputs.new_release_version }} is now available! [Check it out!](https://tabletop.repeatedpleasant.games)" }' \
             ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18905,9 +18905,9 @@
       }
     },
     "node_modules/zustand-middleware-yjs": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/zustand-middleware-yjs/-/zustand-middleware-yjs-1.2.5.tgz",
-      "integrity": "sha512-d/EJOxh3GiqWQE/Rs0wskNJFmfQ9ymv/1MKC2F8IlwtUy0X8xo/ihJSotSakiYPURGAILql1ygHMDaapkOL9MA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/zustand-middleware-yjs/-/zustand-middleware-yjs-1.2.6.tgz",
+      "integrity": "sha512-2WFaLjk6W9SufIm+ATw+lesGEYP+OInz1GzgKH8IgDnOA9kmX/P6cBCmzJW65fIwsN/ixC1b6/f0jwv6+KSZdg==",
       "dependencies": {
         "yjs": "^13.5.11",
         "zustand": "^3.5.5"
@@ -33239,9 +33239,9 @@
       "requires": {}
     },
     "zustand-middleware-yjs": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/zustand-middleware-yjs/-/zustand-middleware-yjs-1.2.5.tgz",
-      "integrity": "sha512-d/EJOxh3GiqWQE/Rs0wskNJFmfQ9ymv/1MKC2F8IlwtUy0X8xo/ihJSotSakiYPURGAILql1ygHMDaapkOL9MA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/zustand-middleware-yjs/-/zustand-middleware-yjs-1.2.6.tgz",
+      "integrity": "sha512-2WFaLjk6W9SufIm+ATw+lesGEYP+OInz1GzgKH8IgDnOA9kmX/P6cBCmzJW65fIwsN/ixC1b6/f0jwv6+KSZdg==",
       "requires": {
         "yjs": "^13.5.11",
         "zustand": "^3.5.5"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import { UserCursorOverlay } from "./feature/user-awareness";
 
 export const App = () =>
 {
-  const { room } = useLocalStore();
+  const room = useLocalStore(({ room }) => room);
 
   return (
     <main

--- a/src/feature/actor/component/ActorList.tsx
+++ b/src/feature/actor/component/ActorList.tsx
@@ -19,6 +19,14 @@ export const ActorList = () =>
     removeActor
   }));
 
+  React.useEffect(
+    () =>
+    {
+      console.log(actors)
+    },
+    [actors]
+  );
+
   return (
     (!actors || actors.length === 0)
     ? (


### PR DESCRIPTION
Addresses #73 and #74. Both were created due to different behaviors. First was a re-creation of the shared document on every local state change. This was due to not using a selector function with the useLocalStore hook. The second was duplication of actors due to a problem in zustand-middleware-yjs, whose diffing algorithm was unable to handle insertions to the start of arrays in versions >1.2.6.