### PR TITLE
Fix token labels intercepting pointer

### DIFF
--- a/src/feature/tabletop/component/Token.tsx
+++ b/src/feature/tabletop/component/Token.tsx
@@ -112,7 +112,7 @@ export const Token = ({
       />
       {
         label
-        ? (<text x={x} y={y}>{label}</text>)
+        ? (<text style={{ pointerEvents: "none" }} x={x} y={y}>{label}</text>)
         : null
       }
     </g>


### PR DESCRIPTION
Fixes #67, where tokens can't be moved if the label of another token is in the way.