### PR TITLE
:bug: Zooming at max zoom does not change x-y coords

### DIFF
--- a/src/feature/grid/component/Grid.spec.tsx
+++ b/src/feature/grid/component/Grid.spec.tsx
@@ -339,4 +339,28 @@ describe("Connected Grid component", () =>
       [   0,   0, 1 ],
     ]);
   });
+
+  it("Reaching max zoom does not wipe out x-y coordinates.", () =>
+  {
+    const clientX = 10, clientY = 12, deltaY = 100;
+
+    useLocalStore.getState().setViewTransform([
+      [ 0.1,   0, 3 ],
+      [   0, 0.1, 4 ],
+      [   0,   0, 0 ],
+    ]);
+
+    const { getByTestId } = renderSVG(<Grid patternId={null} />);
+
+    const grid = getByTestId(gridTestId);
+
+    fireEvent.wheel(grid, { deltaY, clientX, clientY });
+
+    expect(useLocalStore.getState().viewTransform)
+    .toStrictEqual([
+      [ 0.1,   0, 3 ],
+      [   0, 0.1, 4 ],
+      [   0,   0, 1 ],
+    ]);
+  });
 });

--- a/src/feature/grid/component/Grid.tsx
+++ b/src/feature/grid/component/Grid.tsx
@@ -89,12 +89,17 @@ export const Grid = ({ patternId, }: GridProps) =>
             [         , , newY ],
           ] = pan(zoom(viewTransform));
 
+          const [
+            [ , , oldX ],
+            [ , , oldY ],
+          ] = viewTransform;
+
           const actualScale = Math.max(newScale, 0.1);
 
           setViewTransform(
             [
-              [ actualScale,           0, newX ],
-              [           0, actualScale, newY ],
+              [ actualScale,           0, actualScale !== newScale ? oldX : newX ],
+              [           0, actualScale, actualScale !== newScale ? oldY : newY ],
               [           0,           0,    1 ],
             ]
           );


### PR DESCRIPTION
Fixes #71. Turns out that the camera doesn't get set to 0,0, but is inappropriately scaled when we don't actually want to apply any scaling.